### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/vagrant/forum/forumdb.py
+++ b/vagrant/forum/forumdb.py
@@ -47,4 +47,4 @@ def AddPost(content):
     except psycopg2.DatabaseError, e:
         if DB:
             DB.rollback()
-	print "Error '%s'" % e
+	print "Error '{0!s}'".format(e)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Population96:fullstack-nanodegree-vm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Population96:fullstack-nanodegree-vm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
